### PR TITLE
Fix passing in Chrome from config.py

### DIFF
--- a/bga_tm_scraper/bga_session.py
+++ b/bga_tm_scraper/bga_session.py
@@ -29,7 +29,7 @@ class BGASession:
     BASE_URL = 'https://boardgamearena.com'
     LOGIN_URL = '/account/account/login.html'
     
-    def __init__(self, email: str, password: str, chromedriver_path: str, headless: bool = False):
+    def __init__(self, email: str, password: str, chromedriver_path: str, chrome_path: str=None, headless: bool = False):
         """
         Initialize session manager
         
@@ -42,6 +42,7 @@ class BGASession:
         self.email = email
         self.password = password
         self.chromedriver_path = chromedriver_path
+        self.chrome_path = chrome_path
         self.headless = headless
         
         # Session-based components
@@ -133,7 +134,7 @@ class BGASession:
             
             login_resp = self.session.post(f'{self.BASE_URL}{self.LOGIN_URL}', data=login_data)
             login_resp.raise_for_status()
-            
+
             # Verify login by checking for authentication indicators
             if self._verify_session_authentication():
                 self.is_session_logged_in = True
@@ -220,6 +221,10 @@ class BGASession:
             
             # Set user agent to match session requests
             chrome_options.add_argument('--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36')
+
+            if self.chrome_path:
+                # If a custom Chrome path is provided, set it
+                chrome_options.binary_location = self.chrome_path
             
             service = Service(self.chromedriver_path)
             self.driver = webdriver.Chrome(service=service, options=chrome_options)

--- a/bga_tm_scraper/scraper.py
+++ b/bga_tm_scraper/scraper.py
@@ -29,7 +29,7 @@ ARENA_SEASON_21_END = datetime(2025, 7, 8, 23, 59, 59)  # End of day
 class TMScraper:
     """Web scraper for Terraforming Mars replays from BoardGameArena"""
     
-    def __init__(self, chromedriver_path: str, request_delay: int = 1, headless: bool = False, 
+    def __init__(self, chromedriver_path: str, chrome_path: str=None, request_delay: int = 1, headless: bool = False,
                  email: Optional[str] = None, password: Optional[str] = None):
         """
         Initialize the scraper
@@ -42,6 +42,7 @@ class TMScraper:
             password: BGA account password (optional, will try to load from config if not provided)
         """
         self.chromedriver_path = chromedriver_path
+        self.chrome_path = chrome_path
         self.request_delay = request_delay
         self.headless = headless
         self.driver = None
@@ -103,6 +104,7 @@ class TMScraper:
                 email=self.email,
                 password=self.password,
                 chromedriver_path=self.chromedriver_path,
+                chrome_path=self.chrome_path,
                 headless=self.headless
             )
             
@@ -137,7 +139,11 @@ class TMScraper:
         chrome_options.add_argument('--disable-dev-shm-usage')
         chrome_options.add_argument('--disable-gpu')
         chrome_options.add_argument('--window-size=1920,1080')
-        
+
+        if self.chrome_path:
+            # If a custom Chrome path is provided, set it
+            options.binary_location = self.chrome_path
+
         # Set user agent to avoid detection
         chrome_options.add_argument('--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36')
         
@@ -1099,7 +1105,7 @@ class TMScraper:
             title_elem = soup.find('title')
             if title_elem:
                 replay_data['title'] = title_elem.get_text().strip()
-            
+
             # Look for game logs section
             game_logs = soup.find_all('div', class_='replaylogs_move')
             if game_logs:
@@ -1122,7 +1128,7 @@ class TMScraper:
                 player_name = player_elem.get_text().strip()
                 if player_name:
                     replay_data['players'].append(player_name)
-            
+
             logger.info(f"Successfully scraped replay {replay_id}")
             return replay_data
             
@@ -1725,6 +1731,7 @@ class TMScraper:
                     email=self.email,
                     password=self.password,
                     chromedriver_path=self.chromedriver_path,
+                    chrome_path=self.chrome_path,
                     headless=True  # Use headless for session-only initialization
                 )
                 

--- a/config.example.py
+++ b/config.example.py
@@ -3,7 +3,7 @@
 
 # URL templates for constructing BGA URLs
 TABLE_URL_TEMPLATE = "https://boardgamearena.com/table?table={table_id}"
-REPLAY_URL_TEMPLATE = "https://boardgamearena.com/archive/replay/250604-1037/?table={table_id}&player={player_id}&comments={player_id}"
+REPLAY_URL_TEMPLATE = "https://boardgamearena.com/archive/replay/{version_id}/?table={table_id}&player={player_id}&comments={player_id}"
 
 
 # Request settings

--- a/fix_version_ids.py
+++ b/fix_version_ids.py
@@ -134,6 +134,7 @@ class VersionFixer:
             # Initialize scraper with credentials from config
             self.scraper = TMScraper(
                 chromedriver_path=config.CHROMEDRIVER_PATH,
+                chrome_path=config.CHROME_PATH,
                 request_delay=config.REQUEST_DELAY,
                 headless=True,  # Use headless mode for batch processing
                 email=config.BGA_EMAIL,

--- a/get_players.py
+++ b/get_players.py
@@ -10,6 +10,7 @@ session = BGASession(
         email=config.BGA_EMAIL,
         password=config.BGA_PASSWORD,
         chromedriver_path=config.CHROMEDRIVER_PATH,
+        chrome_path=config.CHROME_PATH,
         headless=True
     )
 

--- a/main.py
+++ b/main.py
@@ -156,6 +156,7 @@ def update_players_registry(count: int = 1000) -> bool:
             email=config.BGA_EMAIL,
             password=config.BGA_PASSWORD,
             chromedriver_path=config.CHROMEDRIVER_PATH,
+            chrome_path=config.CHROME_PATH,
             headless=True
         )
         
@@ -192,6 +193,7 @@ def initialize_scraper() -> TMScraper:
     """Initialize and authenticate the scraper"""
     scraper = TMScraper(
         chromedriver_path=config.CHROMEDRIVER_PATH,
+        chrome_path=config.CHROME_PATH,
         request_delay=getattr(config, 'REQUEST_DELAY', 1),
         headless=True,
         email=config.BGA_EMAIL,


### PR DESCRIPTION
Nit: We weren't making use of the config.CHROME_PATH. This passes it in as an option for the webdriver. 

Tested and successfully using the debug version of chrome i wanted to use (rather than my PC's main Chrome version). This helps myself and others that need a custom chrome version and use this.