### PR TITLE
Scrape starting preludes/corporations

### DIFF
--- a/bga_tm_scraper/parser.py
+++ b/bga_tm_scraper/parser.py
@@ -3888,7 +3888,13 @@ class Parser:
         # Convert dataclasses to dictionaries for JSON serialization
         def convert_to_dict(obj):
             if hasattr(obj, '__dict__'):
-                return {k: convert_to_dict(v) for k, v in obj.__dict__.items()}
+                result = {}
+                for k, v in obj.__dict__.items():
+                    # Omit corp_options and prelude_options if they are None (null) since we know these are only relevant turn 1.
+                    if k in ("corp_options", "prelude_options") and v is None:
+                        continue
+                    result[k] = convert_to_dict(v)
+                return result
             elif isinstance(obj, list):
                 return [convert_to_dict(item) for item in obj]
             elif isinstance(obj, dict):


### PR DESCRIPTION
This scrapes the starting prelude and corporations of the selected player. There's no view of both players corps/preludes afaik but let's at least get those of the player whose replay we are watching. This will make for some nice analysis with common pairings of starting corps/preludes imho.

Tested by running "python main.py scrape-complete 715775218:96099926"

I see

    "corp_options": {
        "96099926": [
          "United Nations Mars Initiative",
          "CrediCor"
        ]
      },
      "prelude_options": {
        "96099926": [
          "Eccentric Sponsor",
          "Huge Asteroid",
          "Martian Industries",
          "Polar Industries"
        ]
      },
      
under move_number 1 for the viewing player.